### PR TITLE
Update README env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@ This project uses a Vercel serverless function to create Mercado Pago
 preferences without running into CORS issues. Configure the following
 environment variables in your hosting platform:
 
-- `SUPABASE_URL` – your Supabase project URL.
-- `SUPABASE_SERVICE_KEY` – a service role key with permission to invoke
+- `NEXT_PUBLIC_SUPABASE_URL` – your Supabase project URL.
+- `SUPABASE_SERVICE_ROLE_KEY` – a service role key with permission to invoke
   functions.
+- `MERCADOPAGO_ACCESS_TOKEN` – access token for the Mercado Pago SDK.
 
 The function lives at `api/create-mercadopago-preference.js` and is
-called from the checkout page.
+called from the checkout page. A `405` response is returned if you use
+any HTTP method other than `POST`.


### PR DESCRIPTION
## Summary
- document actual environment variable names
- note 405 responses for non-POST methods

## Testing
- `npm run build` *(fails: "useParams" is not exported)*

------
https://chatgpt.com/codex/tasks/task_e_68570d5bd5d8832dbd62c2fc3ca0bf8a