### PR TITLE
fix: handle flexible color formats in cart

### DIFF
--- a/src/components/CartDrawer.jsx
+++ b/src/components/CartDrawer.jsx
@@ -39,16 +39,21 @@ const CartDrawer = () => {
 
   const renderSelectedColor = (selectedColor) => {
     if (!selectedColor) return null;
+    const value = selectedColor.value || selectedColor.hex || (typeof selectedColor === 'string' ? selectedColor : null);
+    const name = selectedColor.name || selectedColor.label || (typeof selectedColor === 'string' ? selectedColor : null);
+    if (!value && !name) return null;
 
     return (
       <div className="flex items-center gap-2 mt-1">
         <span className="text-xs text-muted-foreground">Color:</span>
         <div className="flex items-center gap-1">
-          <div
-            className="w-4 h-4 rounded-full border border-gray-300"
-            style={{ backgroundColor: selectedColor.value }}
-          />
-          <span className="text-xs font-medium">{selectedColor.name}</span>
+          {value && (
+            <div
+              className="w-4 h-4 rounded-full border border-gray-300"
+              style={{ backgroundColor: value }}
+            />
+          )}
+          {name && <span className="text-xs font-medium">{name}</span>}
         </div>
       </div>
     );

--- a/src/contexts/CartContext.jsx
+++ b/src/contexts/CartContext.jsx
@@ -2,6 +2,14 @@ import React, { createContext, useContext, useReducer, useEffect } from 'react';
 
 const CartContext = createContext();
 
+// Extraer valor hex del color en distintos formatos
+const getColorValue = (color) => {
+  if (!color) return null;
+  if (typeof color === 'string') return color;
+  if (typeof color === 'object') return color.value || color.hex || null;
+  return null;
+};
+
 const cartReducer = (state, action) => {
   switch (action.type) {
     case 'LOAD_CART':
@@ -18,9 +26,8 @@ const cartReducer = (state, action) => {
             .join('|')
         : 'no-variants';
       
-      const colorKey = action.payload.selectedColor 
-        ? `color:${action.payload.selectedColor.value}`
-        : 'no-color';
+      const colorVal = getColorValue(action.payload.selectedColor);
+      const colorKey = colorVal ? `color:${colorVal}` : 'no-color';
       
       const fullKey = `${variantKey}-${colorKey}`;
       
@@ -34,9 +41,8 @@ const cartReducer = (state, action) => {
               .join('|')
           : 'no-variants';
         
-        const itemColorKey = item.selectedColor 
-          ? `color:${item.selectedColor.value}`
-          : 'no-color';
+        const itemColorVal = getColorValue(item.selectedColor);
+        const itemColorKey = itemColorVal ? `color:${itemColorVal}` : 'no-color';
         
         const itemFullKey = `${itemVariantKey}-${itemColorKey}`;
         
@@ -54,9 +60,8 @@ const cartReducer = (state, action) => {
                   .join('|')
               : 'no-variants';
             
-            const itemColorKey = item.selectedColor 
-              ? `color:${item.selectedColor.value}`
-              : 'no-color';
+            const itemColorVal = getColorValue(item.selectedColor);
+            const itemColorKey = itemColorVal ? `color:${itemColorVal}` : 'no-color';
             
             const itemFullKey = `${itemVariantKey}-${itemColorKey}`;
             
@@ -139,9 +144,8 @@ export const CartProvider = ({ children }) => {
           .join('|')
       : 'no-variants';
     
-    const colorKey = product.selectedColor 
-      ? `color:${product.selectedColor.value}`
-      : 'no-color';
+    const colorVal = getColorValue(product.selectedColor);
+    const colorKey = colorVal ? `color:${colorVal}` : 'no-color';
     
     const fullKey = `${variantKey}-${colorKey}`;
     const cartId = `${product.id}-${fullKey}-${Date.now()}`;


### PR DESCRIPTION
## Summary
- normalize selected color values before generating cart keys
- render cart drawer colors defensively for object, hex, or string inputs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6892a2365100832d9b197282a6759876